### PR TITLE
Updated bottle-utils-html to 0.3.7

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -4,7 +4,7 @@ pytz==2015.2
 gevent==1.0.1
 Mako==1.0.1
 pbkdf2==1.3
-bottle-utils-html==0.3.6
+bottle-utils-html==0.3.7
 bottle-utils-ajax==0.3.1
 bottle-utils-lazy==0.3.2
 bottle-utils-i18n==0.3.5


### PR DESCRIPTION
This fixes the dependency version conflict which happens due to
bottle-utils-html and bottle-utils-common explicitly depending on a specific
version of python-dateutil which is different than the one required by
Librarian.

This fix should have no side-effects.