### PR TITLE
Feature/migration using packages

### DIFF
--- a/librarian/utils/databases.py
+++ b/librarian/utils/databases.py
@@ -44,7 +44,6 @@ def apply_migrations(app):
     app.databases = squery.get_databases(database_configs, debug=bottle.DEBUG)
     for db_name, db in app.databases.items():
         migrate(db,
-                app.in_pkg('migrations', db_name),
                 'librarian.migrations.{0}'.format(db_name),
                 app.config)
 

--- a/librarian/utils/migrations.py
+++ b/librarian/utils/migrations.py
@@ -15,8 +15,6 @@ import sqlite3
 import logging
 import importlib
 
-from ..lib.squery import Database
-
 
 MTABLE = 'migrations'   # SQL table in which migration data is stored
 VERSION_SQL = 'select version from %s where id == 0;' % MTABLE


### PR DESCRIPTION
Migration now take a single parameter `package`, that is a package path like 'librarian.migrations.sessions', instead of requiring multiple redundant parameters. The hook has also been updated. (Ignore previous PR, it was against wrong branch.)