### PR TITLE
Added librarian console command

### DIFF
--- a/librarian/app.py
+++ b/librarian/app.py
@@ -109,7 +109,8 @@ def shutdown(*args, **kwargs):
     print('Bye! Have a nice day! Those books are due Tuesday, by the way!')
 
 
-def main(config_path):
+def main():
+    config_path = commands.get_config_path() or app.CONFPATH
     app.config = ConfDict.from_file(config_path, catchall=True, autojson=True)
     app.version = version.get_version(__version__, app.config)
     hooks.register_hooks(app)
@@ -121,9 +122,8 @@ def main(config_path):
     commands.select_command(app)
     # begin app-start sequence
     prestart()
-    return start()
+    sys.exit(start())
 
 
 if __name__ == '__main__':
-    config_path = commands.get_config_path() or app.CONFPATH
-    sys.exit(main(config_path))
+    main()

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,11 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
     ],
+    entry_points = {
+        'console_scripts': [
+            'librarian = librarian.app:main',
+        ],
+    },
     install_requires=DEPS,
     cmdclass={
         'test': PyTest,


### PR DESCRIPTION
This PR adds a console command `librarian` to replace `python -m librarian.app` dance. Stuff from the `if __name__ == '__main__` block were all shoved into the `main()` func.