### PR TITLE
Fix disk space percentage display

### DIFF
--- a/librarian/__init__.py
+++ b/librarian/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3'
+__version__ = '0.4.dev1'
 __author__ = 'Outernet Inc <branko@outernet.is>'

--- a/librarian/plugins/diskspace/views/diskspace/_space_info.tpl
+++ b/librarian/plugins/diskspace/views/diskspace/_space_info.tpl
@@ -1,7 +1,7 @@
 <%namespace name="widgets" file="../_widgets.tpl"/>
 
 <%def name="space(free, total)">
-<% pct = round(free / total * 100, 1) if total != 0 else 100 %>
+<% pct = round((total - free) / float(total) * 100, 1) if total else 100 %>
 ## Translators, %s is the amount of free space in bytes, KB, MB, etc.
 ${widgets.progress(_('Total space (%s free)') % h.hsize(free), pct)}
 </%def>


### PR DESCRIPTION
The disk space indicator in dashboards keeps showing 0% due division bug. This patch fixes that.