### PR TITLE
Fix for failure to stop FSAL cleanly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,49 +73,49 @@ start-compass: $(COMPASS_PID)
 start-coffee: $(COFFEE_PID)
 
 stop-compass:
-	-kill -s TERM $$(cat $(COMPASS_PID))
-	-rm $(COMPASS_PID)
+	@-kill -s TERM $$(cat $(COMPASS_PID))
+	@-rm $(COMPASS_PID)
 
 stop-coffee:
-	-kill -s INT $$(cat $(COFFEE_PID))
-	-rm $(COFFEE_PID)
+	@-kill -s INT $$(cat $(COFFEE_PID))
+	@-rm $(COFFEE_PID)
 
 start-fsal: $(FSAL_PID)
 
 stop-fsal:
-	-kill -s TERM $$(cat $(FSAL_PID))
+	@-kill -s TERM $$(cat $(FSAL_PID))
 
 restart-fsal: stop-fsal
 	# We don't use start as a dependency because we need a 5s pause
-	echo "Waiting for things to settle..."
-	sleep 5
-	make start-fsal
+	@echo "Waiting for things to settle..."
+	@sleep 5
+	@make start-fsal
 
 recompile-assets:
-	compass compile --force -c $(COMPASS_CONF)
-	find $(JS_OUT) -path $(JS_NOPRUNE) -prune -o -name "*.js" -exec rm {} +
-	coffee --bare -c --output $(JS_OUT) $(COFFEE_SRC)
+	@compass compile --force -c $(COMPASS_CONF)
+	@find $(JS_OUT) -path $(JS_NOPRUNE) -prune -o -name "*.js" -exec rm {} +
+	@coffee --bare -c --output $(JS_OUT) $(COFFEE_SRC)
 
 docs: clean-doc
-	make -C $(DOCS) html
+	@make -C $(DOCS) html
 
 clean-doc:
-	make -C $(DOCS) clean
+	@make -C $(DOCS) clean
 
 $(COMPASS_PID): $(TMPDIR)
-	compass watch -c $(COMPASS_CONF) & echo $$! > $@
+	@compass watch -c $(COMPASS_CONF) & echo $$! > $@
 
 $(COFFEE_PID): $(TMPDIR)
-	coffee --bare --watch --output $(JS_OUT) $(COFFEE_SRC) & echo $$! > $@
+	@coffee --bare --watch --output $(JS_OUT) $(COFFEE_SRC) & echo $$! > $@
 
 $(FSAL_PID): $(TMPDIR)
-	fsal-daemon --conf $(FSAL_CONF) --pid-file $@
+	@fsal-daemon --conf $(FSAL_CONF) --pid-file $@
 
 $(FSAL_CONF): $(FSAL_SAMPLE) $(TMPDIR)
-	cat $< | sed 's|PREFIX|$(SITE_PACKAGES)|' > $@
+	@cat $< | sed 's|PREFIX|$(SITE_PACKAGES)|' > $@
 
 $(LIBRARIAN_CONF): $(LIBRARIAN_SAMPLE) $(TMPDIR)
-	cat $< > $@
+	@cat $< > $@
 
 $(TMPDIR):
-	mkdir -p $@
+	@mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,11 @@ JS_OUT = $(OUTPUT_DIR)/js
 JS_NOPRUNE = $(JS_OUT)/vendor
 
 # FSAL-related
+FSAL_SAMPLE = $(SAMPLES)/fsal.ini
 FSAL_CONF := $(TMPDIR)/fsal.ini
 
 # Librarian-related
+LIBRARIAN_SAMPLE = $(SAMPLES)/librarian.ini
 LIBRARIAN_CONF := $(TMPDIR)/librarian.ini
 
 # PID files
@@ -70,19 +72,18 @@ start-compass: $(COMPASS_PID)
 
 start-coffee: $(COFFEE_PID)
 
-stop-compass: $(COMPASS_PID)
-	-kill -s TERM $$(cat $<)
-	-rm $<
+stop-compass:
+	-kill -s TERM $$(cat $(COMPASS_PID))
+	-rm $(COMPASS_PID)
 
-stop-coffee: $(COFFEE_PID)
-	-kill -s INT $$(cat $<)
-	-rm $<
+stop-coffee:
+	-kill -s INT $$(cat $(COFFEE_PID))
+	-rm $(COFFEE_PID)
 
 start-fsal: $(FSAL_PID)
 
-stop-fsal: $(FSAL_PID)
-	-kill -s TERM $$(cat $<)
-	-rm $<
+stop-fsal:
+	-kill -s TERM $$(cat $(FSAL_PID))
 
 restart-fsal: stop-fsal
 	# We don't use start as a dependency because we need a 5s pause
@@ -107,14 +108,14 @@ $(COMPASS_PID): $(TMPDIR)
 $(COFFEE_PID): $(TMPDIR)
 	coffee --bare --watch --output $(JS_OUT) $(COFFEE_SRC) & echo $$! > $@
 
-$(FSAL_PID): $(FSAL_CONF) $(TMPDIR)
-	fsal-daemon --conf $(FSAL_CONF) --pid-file $@ && echo $$! > $@
+$(FSAL_PID): $(TMPDIR)
+	fsal-daemon --conf $(FSAL_CONF) --pid-file $@
 
-$(FSAL_CONF): $(TMPDIR)
-	cat $(SAMPLES)/fsal.ini | sed 's|PREFIX|$(SITE_PACKAGES)|' > $@
+$(FSAL_CONF): $(FSAL_SAMPLE) $(TMPDIR)
+	cat $< | sed 's|PREFIX|$(SITE_PACKAGES)|' > $@
 
-$(LIBRARIAN_CONF): $(TMPDIR)
-	cat $(SAMPLES)/librarian.ini > $@
+$(LIBRARIAN_CONF): $(LIBRARIAN_SAMPLE) $(TMPDIR)
+	cat $< > $@
 
 $(TMPDIR):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Global
 TMPDIR := ./tmp
+LIBRARY = $(TMPDIR)/library
 LOCAL_MIRROR = /tmp/pypi
 MIRROR_REQ = ./dependencies/requirements.txt
 DOCS = ./docs
@@ -80,7 +81,7 @@ stop-coffee:
 	@-kill -s INT $$(cat $(COFFEE_PID))
 	@-rm $(COFFEE_PID)
 
-start-fsal: $(FSAL_PID)
+start-fsal: $(LIBRARY) $(FSAL_PID)
 
 stop-fsal:
 	@-kill -s TERM $$(cat $(FSAL_PID))
@@ -116,6 +117,9 @@ $(FSAL_CONF): $(FSAL_SAMPLE) $(TMPDIR)
 
 $(LIBRARIAN_CONF): $(LIBRARIAN_SAMPLE) $(TMPDIR)
 	@cat $< > $@
+
+$(LIBRARY):
+	@mkdir -p $@
 
 $(TMPDIR):
 	@mkdir -p $@


### PR DESCRIPTION
This PR fixes #245, and issue where make target for stopping FSAL would spawn a new instance and stop that one instead of the old one.