### PR TITLE
Removed twitter-related and other obsolete keys

### DIFF
--- a/docs/samples/librarian.ini
+++ b/docs/samples/librarian.ini
@@ -5,9 +5,8 @@ defaults =
 
 [app]
 
-bind = 0.0.0.0
+bind = 127.0.0.1
 port = 8080
-
 default_route = files:list
 
 [fsal]
@@ -18,19 +17,10 @@ socket = tmp/fsal.ctrl
 
 socket = tmp/ondd.ctrl
 
-[library]
-
-legacy_contentdir = tmp/legacy
-
-[twitter]
-
-refresh_rate = 0
-
 [menu]
 
 main =
     files
-    twitter
 
 [cache]
 
@@ -39,23 +29,21 @@ timeout = 0
 
 [emergency]
 
-file = reset_token
+file = tmp/reset_token
 
 [diskspace]
 
 threshold = 1.5GB
-
 refresh_rate = 3600
 
 [wireless]
 
 config = tmp/hostapd.conf
-
 driver_selection = no
 
 [ondd]
 
-cache_min = 5GB
+cache_min = 500MB
 cache_refresh_rate = 15
 
 [thumbs]


### PR DESCRIPTION
This patch cleans up the sample .ini so it doesn't have keys that aren't really useful or cause the deployment to break. See #246 