### PR TITLE
Add reindex make target and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ FSAL_PID = $(TMPDIR)/.fsal_pid
 	stop-coffee \
 	recompile-assets \
 	reindex \
-	docs
+	docs \
+	clean-doc
 
 prepare: local-mirror $(FSAL_CONF) $(LIBRARIAN_CONF)
 	pip install -e . --upgrade --extra-index-url file://$(LOCAL_MIRROR)/simple

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ JS_NOPRUNE = $(JS_OUT)/vendor
 # FSAL-related
 FSAL_SAMPLE = $(SAMPLES)/fsal.ini
 FSAL_CONF := $(TMPDIR)/fsal.ini
+FSAL_SOCK := $(TMPDIR)/fsal.ctrl
 
 # Librarian-related
 LIBRARIAN_SAMPLE = $(SAMPLES)/librarian.ini
@@ -47,6 +48,7 @@ FSAL_PID = $(TMPDIR)/.fsal_pid
 	stop-compass \
 	stop-coffee \
 	recompile-assets \
+	reindex \
 	docs
 
 prepare: local-mirror $(FSAL_CONF) $(LIBRARIAN_CONF)
@@ -103,6 +105,9 @@ docs: clean-doc
 
 clean-doc:
 	@make -C $(DOCS) clean
+
+reindex: $(FSAL_SOCK)
+	@python scripts/reindex.py -s $(FSAL_SOCK)
 
 $(COMPASS_PID): $(TMPDIR)
 	@compass watch -c $(COMPASS_CONF) & echo $$! > $@

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -38,6 +38,7 @@ Topics covered:
     :maxdepth: 1
 
     download_and_setup
+    local_file_library
     source_code_layout
     architecture_overview
     core_api

--- a/docs/source/local_file_library.rst
+++ b/docs/source/local_file_library.rst
@@ -1,0 +1,23 @@
+Local file library
+==================
+
+While developing Libarian features or external Librarian components, you
+probably want to have some files to work with. If you've folled the
+instructions in :doc:`downoad_and_setup`, you probably have a directory called
+``tmp/library``, which is where the files should be stored.
+
+.. note::
+    If ``tmp/library`` directory does not exist, it will be created when
+    starting FSAL. There is nothing wrong with manually creating it, though.
+
+After adding new files and directories into the library, they need to be
+reindexed by FSAL before they show up. Reindexing can be triggered either by
+restarting FSAL, or by using the ``reindex`` make target.
+
+To restart FSAL::
+
+    $ make restart-fsal
+
+To reindex without restarting FSAL::
+
+    $ make reindex

--- a/docs/source/make_targets.rst
+++ b/docs/source/make_targets.rst
@@ -24,4 +24,5 @@ stop-fsal           stop FSAL
 restart-fsal        resart FSAL
 recompile-assets    recompile the static assets from scractch
 docs                generate the HTML documentation
+clean-doc           clean the generated HTML documentation
 ==================  ===========================================================

--- a/docs/source/make_targets.rst
+++ b/docs/source/make_targets.rst
@@ -25,4 +25,5 @@ restart-fsal        resart FSAL
 recompile-assets    recompile the static assets from scractch
 docs                generate the HTML documentation
 clean-doc           clean the generated HTML documentation
+reindex             initiate FSAL's reindexing of local file collection
 ==================  ===========================================================

--- a/scripts/reindex.py
+++ b/scripts/reindex.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from fsal import client
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--socket', '-s', help='FSAL socket path',
+                        metavar='PATH')
+    args = parser.parse_args()
+    fc = client.FSAL(args.socket)
+    fc.refresh()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This patch adds a `reindex` make target which causes a running FSAL instance to commence reindexing. Matching documentation is also provided.