### PR TITLE
Fix content listing

### DIFF
--- a/librarian/commands/facets.py
+++ b/librarian/commands/facets.py
@@ -11,7 +11,7 @@ class RefillFacetsCommand(object):
         print('Begin facets refill.')
         config = supervisor.config
         archive = Archive(fsal=supervisor.exts.fsal,
-                          db=supervisor.exts.databases.facets,
+                          db=supervisor.exts.databases.meta,
                           tasks=supervisor.exts.tasks,
                           config=config)
         archive.clear_and_reload()


### PR DESCRIPTION
Use the same method for filtering both dirs and files so they are treated the same way, allowing it to drop out entries that have no corresponding metadata fetched from the database.

Previously two different methods were used, of which the one used for directories didn't ignore entries with missing metadata, causing an unhandled `KeyError` exception.