### PR TITLE
Fix typo in methodname of getting consolidate status

### DIFF
--- a/librarian/dashboard/diskspace.py
+++ b/librarian/dashboard/diskspace.py
@@ -37,4 +37,4 @@ class DiskspaceDashboardPlugin(DashboardPlugin):
     def get_context(self):
         CheckDiskspaceTask().run()
         return dict(storages=storage.get_content_storages(),
-                    active_storage_id=storage.get_consoildate_status())
+                    active_storage_id=storage.get_consolidate_status())


### PR DESCRIPTION
Diskspace dashboard plugin failed to load because of a typo in the method name for getting consolidation status in the initial load of the dashboard plugin.