### PR TITLE
Adapt plugins to make them usable by the collector api

### DIFF
--- a/librarian/plugins/captive.py
+++ b/librarian/plugins/captive.py
@@ -1,37 +1,37 @@
+import functools
 import logging
 
 from bottle import HTTPResponse, redirect
 
 from ..core.contrib.templates.renderer import template
+from ..core.exts import ext_container as exts
 from ..utils import netutils
 
 
-def captive_portal_plugin(supervisor):
-    domains = supervisor.config['captive_portal.domains']
+def captive_portal_plugin(fn):
+    domains = exts.config['captive_portal.domains']
     domain_mappings = dict(d.split(':') for d in domains)
-    self_url = supervisor.config['app.root_url'] + '/'
+    self_url = exts.config['app.root_url'] + '/'
 
-    def decorator(callback):
-        def wrapper(*args, **kwargs):
-            target_host = netutils.get_target_host()
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        target_host = netutils.get_target_host()
 
-            if target_host not in domain_mappings:
-                # No domain matches captive portal check
-                return callback(*args, **kwargs)
+        if target_host not in domain_mappings:
+            # No domain matches captive portal check
+            return fn(*args, **kwargs)
 
-            logging.debug('Matched captive portal host %s', target_host)
-
-            # The domain_mappings map domain names to combination of
-            # template name and status code (some captive portal detection
-            # algorithms look for 204 status code instead of 200).
-            template_name, status = domain_mappings[target_host].split(';')
-
-            if status == '204':
-                response = ''
-            elif status == '302':
-                return redirect(self_url, 302)
-            else:
-                response = template(template_name, {})
-            raise HTTPResponse(response, int(status))
-        return wrapper
-    return decorator
+        logging.debug('Matched captive portal host %s', target_host)
+        # The domain_mappings map domain names to combination of
+        # template name and status code (some captive portal detection
+        # algorithms look for 204 status code instead of 200).
+        template_name, status = domain_mappings[target_host].split(';')
+        if status == '204':
+            response = ''
+        elif status == '302':
+            return redirect(self_url, 302)
+        else:
+            response = template(template_name, {})
+        raise HTTPResponse(response, int(status))
+    return wrapper
+captive_portal_plugin.name = 'captive_portal_plugin'

--- a/librarian/plugins/lock.py
+++ b/librarian/plugins/lock.py
@@ -5,13 +5,12 @@ from bottle import request, abort
 from ..utils.lock import is_locked
 
 
-def plugin(supervisor):
-    def decorator(callback):
-        @functools.wraps(callback)
-        def wrapper(*args, **kwargs):
-            unlocked = request.route.config.get('unlocked', False)
-            if not unlocked and is_locked():
-                abort(503, 'Librarian is locked')
-            return callback(*args, **kwargs)
-        return wrapper
-    return decorator
+def lock_plugin(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        unlocked = request.route.config.get('unlocked', False)
+        if not unlocked and is_locked():
+            abort(503, 'Librarian is locked')
+        return fn(*args, **kwargs)
+    return wrapper
+lock_plugin.name = 'lock_plugin'

--- a/librarian/plugins/timer.py
+++ b/librarian/plugins/timer.py
@@ -1,15 +1,8 @@
 from ..utils.timer import request_timer
 
 
-EXPORTS = {
-    'total_timer_plugin': {},
-    'handler_timer_plugin': {}
-}
+total_timer_plugin = request_timer('Total')
+total_timer_plugin.name = 'total_timer_plugin'
 
-
-def total_timer_plugin(supervisor):
-    return request_timer('Total')
-
-
-def handler_timer_plugin(supervisor):
-    return request_timer('Handler')
+handler_timer_plugin = request_timer('Handler')
+handler_timer_plugin.name = 'handler_timer_plugin'


### PR DESCRIPTION
This PR just removes the wrapper function that was around the plugins as it was required in librarian 3.x for them to be installed, and assigns an explicit name to each of them.