### PR TITLE
Fix/superuser step

### DIFF
--- a/librarian/setup/auth.py
+++ b/librarian/setup/auth.py
@@ -19,7 +19,7 @@ class CSRFSecretGenerator:
 class SuperuserStep:
     name = 'superuser'
     index = 2
-    template = 'setup/step_superuser.tpl',
+    template = 'setup/step_superuser.tpl'
 
     @staticmethod
     @identify_database

--- a/librarian/setup/auth.py
+++ b/librarian/setup/auth.py
@@ -3,6 +3,7 @@ from bottle import request
 from ..core.contrib.auth.helpers import identify_database
 from ..core.contrib.auth.users import User
 from ..core.contrib.auth.utils import generate_random_key
+from ..core.exts import ext_container as exts
 from ..forms.auth import RegistrationForm
 
 
@@ -45,6 +46,6 @@ class SuperuserStep:
         User.create(form.processed_data['username'],
                     form.processed_data['password1'],
                     is_superuser=True,
-                    db=request.db.auth,
+                    db=exts.databases.auth,
                     reset_token=reset_token)
         return dict(successful=True)


### PR DESCRIPTION
This PR fixes a typo in the superuser step which caused the template name to become a tuple instead of a string. It also switches the obsolete database access method through the request object to use the ext container instead.