### PR TITLE
Fix/folder meta updating

### DIFF
--- a/librarian/data/meta/metadata.py
+++ b/librarian/data/meta/metadata.py
@@ -240,6 +240,16 @@ class DirectoryMetadata(BaseMetadata):
 
     SPLITTER = '='
     ENTRY_REGEX = re.compile(r'(\w+)\[(\w+)\]')
+    DEFAULT_COVER = 'cover.jpg'
+
+    def _add_default_cover(self, data):
+        # add default cover image filename under ``cover`` key if it exists
+        folder_path = os.path.dirname(self.path)
+        cover_path = os.path.join(folder_path, self.DEFAULT_COVER)
+        if self.fsal.exists(cover_path):
+            # the path of the cover should be relative to the folder where it's
+            # contained
+            data[NO_LANGUAGE]['cover'] = self.DEFAULT_COVER
 
     def extract(self):
         data = dict()
@@ -256,4 +266,9 @@ class DirectoryMetadata(BaseMetadata):
                 language = NO_LANGUAGE
             data.setdefault(language, {})
             data[language][key] = value.strip()
+        # if there is no folder cover image under the language-less version of
+        # the metadata, check for the default cover and add if available
+        if not data[NO_LANGUAGE].get('cover'):
+            self._add_default_cover(data)
+
         return data

--- a/librarian/data/meta/processors.py
+++ b/librarian/data/meta/processors.py
@@ -96,17 +96,19 @@ class Processor(object):
         else:
             self.metadata_extractor = None
 
-    @staticmethod
-    def _merge(source, destination):
+    def _merge(self, source, destination):
         """
         Copy dict of lang:metadata pairs from ``source`` into ``destination``.
         """
         # iterate over ``source``'s lang:meta pairs
         for (language, src_section) in source.items():
+            # drop any unknown keys from the newly extracted metadata
+            filtered_section = dict((k, v) for (k, v) in src_section.items()
+                                    if k in self.keys)
             # existing metadata might not have the current language
             dest_section = destination.get(language, {})
             # merge ``language``'s ``src_section`` into ``dest_section``
-            dest_section.update(src_section)
+            dest_section.update(filtered_section)
             # put back (or insert) merged ``dest_section`` that was just
             # updated with ``src_section`` into ``desctination``
             destination[language] = dest_section
@@ -132,11 +134,9 @@ class Processor(object):
             return {}
         # perform full (possibly expensive) processing of metadata
         try:
-            meta = self.metadata_extractor.extract()
+            return self.metadata_extractor.extract()
         except MetadataError:
             return {}
-        else:
-            return dict((k, v) for (k, v) in meta.items() if k in self.keys)
 
     def _add_metadata(self, dest):
         """

--- a/librarian/helpers/filemanager.py
+++ b/librarian/helpers/filemanager.py
@@ -127,18 +127,17 @@ def join(*args):
 
 @template_helper(namespace='facets')
 def get_folder_cover(fsobj):
-    cover = fsobj.meta.get('cover', request.locale)
-    if cover:
-        # There is a cover image
-        cover_path = fsobj.other_path(cover)
-        return quoted_url('filemanager:direct', path=cover_path)
-    # Look for default cover
-    default_cover = fsobj.other_path('cover.jpg')
-    if not request.app.supervisor.exts.fsal.exists(default_cover):
+    """
+    Return the URL of the cover image belonging to the passed in folder
+    ``fsobj`` under the current locale.
+    """
+    cover = fsobj.meta.get('cover', language=request.locale)
+    if not cover:
+        # No cover image found (default is checked for in the meta extractor)
         return
-    fsobj.dirinfo.set('cover', 'cover.jpg')
-    fsobj.dirinfo.store()
-    return quoted_url('filemanager:direct', path=default_cover)
+    # There is a cover image
+    cover_path = fsobj.other_path(cover)
+    return quoted_url('filemanager:direct', path=cover_path)
 
 
 @template_helper(namespace='facets')

--- a/tests/data/meta/test_processors.py
+++ b/tests/data/meta/test_processors.py
@@ -6,12 +6,12 @@ import librarian.data.meta.processors as mod
 from librarian.data.meta.metadata import MetadataError
 
 
-def test__merge():
+def test_merge():
     dest = {'en': {'title': 'Tests'},
             'rs': {'title': 'Testovi'}}
-    source = {'en': {'description': 'Invention'},
-              'rs': {'description': 'Izum'}}
-    mod.Processor._merge(source, dest)
+    source = {'en': {'description': 'Invention', 'junk': 'gibberish'},
+              'rs': {'description': 'Izum', 'invalid': 'trashcan'}}
+    mod.HtmlProcessor('path')._merge(source, dest)
     assert dest == {'en': {'title': 'Tests', 'description': 'Invention'},
                     'rs': {'title': 'Testovi', 'description': 'Izum'}}
 
@@ -50,7 +50,7 @@ def test_get_metadata_error(metadata_class):
 
 @mock.patch.object(mod.ImageProcessor, 'metadata_class')
 def test_get_metadata(metadata_class):
-    mocked_meta = dict(width=1, height=2, insignificant=3)
+    mocked_meta = dict(width=1, height=2)
     metadata_class.return_value.extract.return_value = mocked_meta
     proc = mod.ImageProcessor('/path/file', partial=False)
     assert proc.get_metadata() == {'width': 1, 'height': 2}
@@ -60,7 +60,7 @@ def test_get_metadata(metadata_class):
 def test__add_metadata(get_metadata):
     get_metadata.return_value = {'width': 1, 'height': 2}
     dest = {'content_types': 1, 'metadata': {'': {'title': 'Fascinating'}}}
-    proc = mod.GenericProcessor('/path/')
+    proc = mod.ImageProcessor('/path/')
     proc._add_metadata(dest)
     expected = {'content_types': 1,
                 'metadata': {'': {'title': 'Fascinating',


### PR DESCRIPTION
-Fixes issue with collecting multi-language metadata (at the moment impacting dirinfo files), where they were accidentally filtered out by the processor because the metadata itself was not on the top level of the structure, but under a language key.
-Moves default cover image lookup from the template helper to the metadata extractor, as dirinfo objects are neither available anymore, nor they are updateable from the outside.