### PR TITLE
Fix database name in links module

### DIFF
--- a/librarian/data/meta/links.py
+++ b/librarian/data/meta/links.py
@@ -7,7 +7,7 @@ from sqlize_pg.builder import Replace, Delete, Select
 from ...core.exts import ext_container as exts
 
 
-DATABASE_NAME = 'meta'
+DATABASE_NAME = 'librarian'
 TABLE_NAME = 'links'
 
 REPLACE_QUERY = Replace(TABLE_NAME,


### PR DESCRIPTION
Fixes the name of the database being access in `links` module (leftover from the transition to the unified librarian database)