### PR TITLE
Fix broken test after fixing setup diag route handler

### DIFF
--- a/librarian/routes/setup.py
+++ b/librarian/routes/setup.py
@@ -32,13 +32,23 @@ class Diag(TemplateRoute):
     template_func = template
     template_name = 'diag'
 
+    #: Default number of lines to be returned from the tail of a logfile
+    DEFAULT_LINES = 100
+
+    def get_lines(self):
+        try:
+            return int(self.request.params.get('lines', self.DEFAULT_LINES))
+        except (ValueError, TypeError):
+            return self.DEFAULT_LINES
+
     def get_log_iterator(self):
         logpath = self.config['logging.syslog']
         if not os.path.exists(logpath):
             return []
 
+        lines = self.get_lines()
         with open(logpath, 'rt') as log:
-            return iter_log(log, 100)
+            return iter_log(log, lines)
 
     def get(self):
         if exts.setup_wizard.is_completed:

--- a/tests/routes/test_setup_routes.py
+++ b/tests/routes/test_setup_routes.py
@@ -17,8 +17,10 @@ def test_iter_log():
 
 @mock.patch.object(mod, 'iter_log')
 @mock.patch.object(builtins, 'open')
+@mock.patch.object(mod.os.path, 'exists')
 @mock.patch.object(mod.Diag, 'request')
-def test_diag_get_log_iterator(request, open_fn, iter_log):
+def test_diag_get_log_iterator(request, exists, open_fn, iter_log):
+    exists.return_value = True
     mocked_file = mock.Mock()
     mocked_file.read.return_value = ''
     ctx_manager = mock.MagicMock()
@@ -28,7 +30,7 @@ def test_diag_get_log_iterator(request, open_fn, iter_log):
     route.config = {'logging.syslog': '/var/log/messages'}
     assert route.get_log_iterator() == iter_log.return_value
     open_fn.assert_called_once_with('/var/log/messages', 'rt')
-    iter_log.assert_called_once_with(mocked_file)
+    iter_log.assert_called_once_with(mocked_file, 100)
 
 
 @mock.patch.object(mod, 'exts')


### PR DESCRIPTION
This PR fixes the broken unittest with the merge of the change to `NonIterableRouteBase` route bases.