### PR TITLE
Fix analytics

### DIFF
--- a/librarian/views/filemanager/_audio.tpl
+++ b/librarian/views/filemanager/_audio.tpl
@@ -67,6 +67,7 @@
     file = entry.name
     current = entry.name == selected_entry.name
     file_path = entry.rel_path
+    mimetype = entry.meta.mime_type or ''
     url = i18n_url('filemanager:list', view=view, path=path, selected=file)
     meta_url = i18n_url('filemanager:details', view=view, path=path, info=file)
     direct_url = h.quoted_url('filemanager:direct', path=file_path)
@@ -85,6 +86,9 @@
         data-title="${title | h}"
         data-author="${author | h}"
         data-duration="${duration}"
+        data-mimetype="${mimetype | h}"
+        data-type="file"
+        data-relpath="${file_path | h.urlquote}"
         data-url="${url}"
         data-meta-url="${meta_url}"
         data-direct-url="${direct_url}"

--- a/librarian/views/filemanager/_folder.tpl
+++ b/librarian/views/filemanager/_folder.tpl
@@ -18,8 +18,13 @@
     </form>
 </%def>
 
-<%def name="file_download(path)">
-    <a href="${h.quoted_url('filemanager:direct', path=path, dl=1)}" class="file-list-control">
+<%def name="file_download(fso)">
+    <a
+        href="${h.quoted_url('filemanager:direct', path=fso.rel_path, dl=1)}"
+        data-relpath="${fso.rel_path | h.urlquote}"
+        data-type="download"
+        class="file-list-control"
+        >
         <span class="icon icon-download-outline"></span>
         <span class="label">${_('Download')}</span>
     </a>
@@ -51,9 +56,10 @@
     dpath = i18n_url('filemanager:list', path=d.rel_path, **varg)
     cover_url = th.facets.get_folder_cover(d)
     icon, icon_is_url = th.facets.get_folder_icon(d)
+    h.urlquote  # likely a Mako bug, if not accessed here, h.urlquote will be unavailable in context below
     %>
     <li class="file-list-item file-list-directory${' with-controls' if with_controls else ''}" role="row" aria-selected="false" tabindex>
-        <a href="${dpath}" data-type="directory" class="file-list-link">
+        <a href="${dpath}" data-type="directory" data-relpath="${d.rel_path | h.urlquote}" class="file-list-link">
             ## COVER/ICON
             % if cover_url:
                 ${self.thumb_block(cover_url, 'cover')}
@@ -135,7 +141,7 @@
             % if is_search:
                 ${self.file_parent_folder(parent_url)}
             % endif
-            ${self.file_download(f.rel_path)}
+            ${self.file_download(f)}
             % if with_controls:
                 % if request.user.is_superuser:
                     ${self.file_delete(f.rel_path)}

--- a/librarian/views/filemanager/_image.tpl
+++ b/librarian/views/filemanager/_image.tpl
@@ -55,6 +55,7 @@
         file = entry.name
         current = entry == selected_entry
         file_path = entry.rel_path
+        mimetype = entry.meta.mime_type or ''
         url = i18n_url('filemanager:list', view=view, path=path, selected=file)
         meta_url = i18n_url('filemanager:details', view=view, path=path, info=file)
         direct_url = h.quoted_url('filemanager:direct', path=file_path)
@@ -69,6 +70,9 @@
     role="row"
     aria-selected="false"
     data-title="${title | h}"
+    data-mimetype="${mimetype | h}"
+    data-type="file"
+    data-relpath="${file_path | h.urlquote}"
     data-direct-url="${direct_url}"
     data-url="${url}"
     data-img-width="${img_width}"

--- a/librarian/views/filemanager/_playlist.tpl
+++ b/librarian/views/filemanager/_playlist.tpl
@@ -92,7 +92,13 @@
     </h2>
     ${self.sidebar_playlist_item_metadata(entry)}
     <p class="playlist-metadata-buttons">
-        <a href="${h.quoted_url('filemanager:direct', path=entry.rel_path, dl=1)}" class="button" target="_blank">
+        <a
+            href="${h.quoted_url('filemanager:direct', path=entry.rel_path, dl=1)}"
+            data-relpath="${entry.rel_path | h.urlquote}"
+            data-type="download"
+            class="button file-list-download"
+            target="_blank"
+            >
             <span class="icon icon-download"></span>
             <span class="label">
                 ${_('Download')}

--- a/librarian/views/filemanager/_video.tpl
+++ b/librarian/views/filemanager/_video.tpl
@@ -43,6 +43,7 @@
         file = entry.name
         current = entry.name == selected_entry.name
         file_path = entry.rel_path
+        mimetype = entry.meta.mime_type or ''
         url = i18n_url('filemanager:list', view=view, path=path, selected=file)
         meta_url = i18n_url('filemanager:details', view=view, path=path, info=file)
         direct_url = h.quoted_url('filemanager:direct', path=file_path)
@@ -63,6 +64,9 @@
     data-duration="${duration}"
     data-width="${width}"
     data-height="${height}"
+    data-mimetype="${mimetype | h}"
+    data-type="file"
+    data-relpath="${file_path | h.urlquote}"
     data-url="${url}"
     data-meta-url="${meta_url}"
     data-direct-url="${direct_url}">


### PR DESCRIPTION
This PR backports the fixes already applied in librarian-filemanager to librarian 4.0 so that all buttons and links are intercepted properly with accurate data.