### PR TITLE
Setup wizard customizations

### DIFF
--- a/docs/source/developers/index.rst
+++ b/docs/source/developers/index.rst
@@ -47,3 +47,4 @@ Topics covered:
     working_with_events
     command_line_arguments
     writing_component_member_collectors
+    setup_wizard

--- a/docs/source/developers/setup_wizard.rst
+++ b/docs/source/developers/setup_wizard.rst
@@ -16,5 +16,5 @@ unused one
 Language Selection     10
 Superuser Credentials  20
 SDR100 Installation    25
-ONDD Settings           30
+ONDD Settings          30
 =====================  =====

--- a/docs/source/developers/setup_wizard.rst
+++ b/docs/source/developers/setup_wizard.rst
@@ -1,0 +1,20 @@
+Setup Wizard
+============
+
+
+Step Indices
+------------
+The setup wizard orders the steps based on indices specified by the steps, with 
+lower indices occuring before higher ones and the wizard ignores any gaps between 
+the indices. Steps which need to interject themselves between others can use any 
+unused one
+
+
+=====================  =====
+        Step           Index
+=====================  =====
+Language Selection     10
+Superuser Credentials  20
+SDR100 Installation    25
+ONDD Settings           30
+=====================  =====

--- a/librarian/setup/auth.py
+++ b/librarian/setup/auth.py
@@ -19,7 +19,7 @@ class CSRFSecretGenerator:
 
 class SuperuserStep:
     name = 'superuser'
-    index = 2
+    index = 20
     template = 'setup/step_superuser.tpl'
 
     @staticmethod

--- a/librarian/setup/language.py
+++ b/librarian/setup/language.py
@@ -8,7 +8,7 @@ from ..forms.setup import get_language_form
 
 class LanguageStep:
     name = 'language'
-    index = 1
+    index = 10
     template = 'setup/step_language.tpl'
 
     @staticmethod

--- a/librarian/setup/ondd.py
+++ b/librarian/setup/ondd.py
@@ -9,7 +9,7 @@ from ..helpers.ondd import read_ondd_setup
 
 class ONDDStep:
     name = 'ondd'
-    index = 3
+    index = 30
     template = 'setup/step_ondd.tpl'
 
     @staticmethod

--- a/librarian/views/setup/setup_base.tpl
+++ b/librarian/views/setup/setup_base.tpl
@@ -33,7 +33,8 @@
         </h2>
         <%block name="step_desc"/>
         <div class="setup-wizard full-page-form">
-            ${h.form('POST', action=i18n_url('setup:enter') + h.set_qparam(**{step_param: step_index}).to_qs())}
+            <% multipart = True if step_multipart else False  %>
+            ${h.form('POST', action=i18n_url('setup:enter') + h.set_qparam(**{step_param: step_index}).to_qs(), multipart=multipart)}
                 <%block name="step"/>
                 <p class="buttons">
                     % if step_index - 1 >= start_index:


### PR DESCRIPTION
This PR bumps existing setup wizard step indices & creates spaces in between for other components to interject themselves.
This also enables individual steps to enable multipart form encoding by setting `step_multipart` to True in their template context.