### PR TITLE
Fix error handler route registration

### DIFF
--- a/librarian/hooks.py
+++ b/librarian/hooks.py
@@ -1,5 +1,3 @@
-from bottle import error
-
 from fsal.client import FSAL
 from ondd_ipc.ipc import ONDDClient
 
@@ -22,10 +20,10 @@ def initialize(supervisor):
     exts.notifications.on_send(invalidate_notification_cache)
     exts.ondd = ONDDClient(exts.config['ondd.socket'])
     # register error handler routes
-    error(403)(system.error_403)
-    error(404)(system.error_404)
-    error(500)(system.error_500)
-    error(503)(system.error_503)
+    supervisor.app.error(403)(system.error_403)
+    supervisor.app.error(404)(system.error_404)
+    supervisor.app.error(500)(system.error_500)
+    supervisor.app.error(503)(system.error_503)
 
 
 @hook('init_complete')


### PR DESCRIPTION
Register error handlers with our specific app instance, not allowing bottle to use default_app (I guess)

This behavior was already observed with hook as well, where registering hooks through the global bottle.hook function didn't trigger them, while registering them through `app_instance.hook` did. 