### PR TITLE
Factor out tuner presets into separate module

### DIFF
--- a/librarian/data/tuner_presets.py
+++ b/librarian/data/tuner_presets.py
@@ -1,0 +1,99 @@
+from collections import namedtuple
+
+from bottle_utils.i18n import lazy_gettext as _
+
+
+__all__ = ('LBAND', 'KUBAND', 'L_PRESETS', 'KU_PREETS', 'PRESETS')
+
+
+Preset = namedtuple('Preset', ('label', 'index', 'values'))
+
+LBAND = 'l'
+KUBAND = 'ku'
+
+L_PRESETS = [
+    # Translators, name of the L-band tuner preset covering most of the world
+    Preset(_('Global'), 1, {
+        'frequency': '1545.525',
+        'uncertainty': '4000',
+        'symbolrate': '8400',
+        'sample_rate': '1',
+        'rf_filter': '0.2',
+        'descrambler': True,
+        # Translators, used as coverage area of a transponder
+        'coverage': _('Europe, Africa, Asia'),
+    }),
+    # Translators, name of the L-band tuner preset covering the Americas
+    Preset(_('Americas'), 2, {
+        'frequency': '1539.8725',
+        'uncertainty': '4000',
+        'symbolrate': '4200',
+        'sample_rate': '1',
+        'rf_filter': '0.2',
+        'descrambler': True,
+        # Translators, used as coverage area of a transponder
+        'coverage': _('North and South America'),
+    }),
+]
+
+KU_PRESETS = [
+    Preset('Galaxy 19 (97.0W)', 1, {
+        'frequency': '11929',
+        'symbolrate': '22000',
+        'polarization': 'v',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('North America'),
+    }),
+    Preset('Hotbird 13 (13.0E)', 2, {
+        'frequency': '11471',
+        'symbolrate': '27500',
+        'polarization': 'v',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('Europe, North Africa'),
+    }),
+    Preset('Intelsat 20 (68.5E)', 3, {
+        'frequency': '12522',
+        'symbolrate': '27500',
+        'polarization': 'v',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('North and West Europe, Subsaharan Africa'),
+    }),
+    Preset('AsiaSat 5 C-band (100.5E)', 4, {
+        'frequency': '3960',
+        'symbolrate': '30000',
+        'polarization': 'h',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('Middle East, Asia, Australia'),
+    }),
+    Preset('Eutelsat (113.0W)', 5, {
+        'frequency': '12089',
+        'symbolrate': '11719',
+        'polarization': 'h',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('North, Middle, and South America'),
+    }),
+    Preset('ABS-2 (74.9E)', 6, {
+        'frequency': '11734',
+        'symbolrate': '44000',
+        'polarization': 'h',
+        'delivery': 'DVB-S',
+        'modulation': 'QPSK',
+        # Translators, used as coverage area of a transponder
+        'coverage': _('India'),
+    }),
+]
+
+PRESETS = {
+    LBAND: L_PRESETS,
+    KUBAND: KU_PRESETS,
+}

--- a/librarian/helpers/ondd.py
+++ b/librarian/helpers/ondd.py
@@ -9,14 +9,13 @@ import ondd_ipc.consts as ondd_consts
 
 from ..core.exts import ext_container as exts
 from ..core.contrib.templates.decorators import template_helper
+from ..data.tuner_presets import LBAND, KUBAND, L_PRESETS, KU_PRESETS, PRESETS
 
-LBAND = 'l'
-KUBAND = 'ku'
 
 #: The key in the application settings JSON file that contains the tuner params
 SETTINGS_KEYS = {
-    'l': 'ondd_l',
-    'ku': 'ondd'
+    LBAND: 'ondd_l',
+    KUBAND: 'ondd'
 }
 
 DELIVERY = (
@@ -60,95 +59,6 @@ RF_FILTERS = (  # EBW%
     ('0.2', '20%'),
     ('0.4', '40%')
 )
-
-Preset = namedtuple('Preset', ('label', 'index', 'values'))
-
-L_PRESETS = [
-    # Translators, name of the L-band tuner preset covering most of the world
-    Preset(_('Global'), 1, {
-        'frequency': '1545.525',
-        'uncertainty': '4000',
-        'symbolrate': '8400',
-        'sample_rate': '1',
-        'rf_filter': '0.2',
-        'descrambler': True,
-        # Translators, used as coverage area of a transponder
-        'coverage': _('Europe, Africa, Asia'),
-    }),
-    # Translators, name of the L-band tuner preset covering the Americas
-    Preset(_('Americas'), 2, {
-        'frequency': '1539.8725',
-        'uncertainty': '4000',
-        'symbolrate': '4200',
-        'sample_rate': '1',
-        'rf_filter': '0.2',
-        'descrambler': True,
-        # Translators, used as coverage area of a transponder
-        'coverage': _('North and South America'),
-    }),
-]
-
-KU_PRESETS = [
-    Preset('Galaxy 19 (97.0W)', 1, {
-        'frequency': '11929',
-        'symbolrate': '22000',
-        'polarization': 'v',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('North America'),
-    }),
-    Preset('Hotbird 13 (13.0E)', 2, {
-        'frequency': '11471',
-        'symbolrate': '27500',
-        'polarization': 'v',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('Europe, North Africa'),
-    }),
-    Preset('Intelsat 20 (68.5E)', 3, {
-        'frequency': '12522',
-        'symbolrate': '27500',
-        'polarization': 'v',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('North and West Europe, Subsaharan Africa'),
-    }),
-    Preset('AsiaSat 5 C-band (100.5E)', 4, {
-        'frequency': '3960',
-        'symbolrate': '30000',
-        'polarization': 'h',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('Middle East, Asia, Australia'),
-    }),
-    Preset('Eutelsat (113.0W)', 5, {
-        'frequency': '12089',
-        'symbolrate': '11719',
-        'polarization': 'h',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('North, Middle, and South America'),
-    }),
-    Preset('ABS-2 (74.9E)', 6, {
-        'frequency': '11734',
-        'symbolrate': '44000',
-        'polarization': 'h',
-        'delivery': 'DVB-S',
-        'modulation': 'QPSK',
-        # Translators, used as coverage area of a transponder
-        'coverage': _('India'),
-    }),
-]
-
-PRESETS = {
-    LBAND: L_PRESETS,
-    KUBAND: KU_PRESETS,
-}
 
 
 class DemodRestartError(Exception):


### PR DESCRIPTION
This commit factors tuner presets out of the helpers module such that it can be
updated separately.