### PR TITLE
Label is already translated at the point where it's possible values a…

### DIFF
--- a/librarian/views/filemanager/_main.tpl
+++ b/librarian/views/filemanager/_main.tpl
@@ -72,7 +72,7 @@ def get_views(facet_types):
             %>
             <a class="views-tabs-strip-tab ${'views-tabs-tab-current' if is_current else ''}" href="${view_url}" role="tab" data-view="${name}">
                 <span class="icon icon-${icon}"></span>
-                <span class="views-tabs-tab-label label">${_(label)}</span>
+                <span class="views-tabs-tab-label label">${label}</span>
             </a>
         % endfor
     </nav>


### PR DESCRIPTION
Fixes this traceback:
```
Traceback (most recent call last):
  File "/usr/bin/bottle.py", line 922, in _cast
    iout = iter(out)
  File "/usr/lib/python2.7/site-packages/streamline/base.py", line 159, in __iter__
    self.create_response()
  File "/usr/lib/python2.7/site-packages/streamline/template.py", line 117, in create_response
    super(XHRPartialRoute, self).create_response()
  File "/usr/lib/python2.7/site-packages/streamline/template.py", line 95, in create_response
    self.body = self.render_template()
  File "/usr/lib/python2.7/site-packages/streamline/template.py", line 80, in render_template
    return fn(template, ctx)
  File "/usr/bin/bottle.py", line 3592, in template
    return TEMPLATES[tplid].render(kwargs)
  File "/usr/lib/python2.7/site-packages/librarian/core/contrib/templates/renderer.py", line 44, in render
    return self.tpl.render(**_defaults)
  File "/usr/lib/python2.7/site-packages/mako/template.py", line 443, in render
    return runtime._render(self, self.callable_, args, data)
  File "/usr/lib/python2.7/site-packages/mako/runtime.py", line 803, in _render
    **_kwargs_for_callable(callable_, data))
  File "/usr/lib/python2.7/site-packages/mako/runtime.py", line 835, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/usr/lib/python2.7/site-packages/mako/runtime.py", line 860, in _exec_template
    callable_(context, *args, **kwargs)
  File "/tmp/mako_cache/base.tpl.py", line 169, in render_body
    context['self'].main(**pageargs)
  File "filemanager_main", line 208, in render_main
  File "/tmp/mako_cache/filemanager/_main.tpl.py", line 124, in render_body
    __M_writer(unicode(_(label)))
TypeError: coercing to Unicode: need string or buffer, Lazy found
```