### PR TITLE
Fix search for paths that end with a slash and have a direct match

### DIFF
--- a/librarian/data/meta/archive.py
+++ b/librarian/data/meta/archive.py
@@ -44,6 +44,8 @@ class FSWriter(object):
         self._cache = cache
         # unpack data
         self._path = data['path']
+        if self._path:
+            self._path = os.path.normpath(self._path)
         self._parent_path = os.path.dirname(self._path)
         self._type = data['type']
         self._mime_type = data['mime_type']


### PR DESCRIPTION
Fixes the below shown error when searching for a path ending with a slash:

 ```
Traceback (most recent call last):
  File "/usr/bin/bottle.py", line 922, in _cast
    iout = iter(out)
  File "/usr/lib/python2.7/site-packages/streamline/base.py", line 159, in __iter__
    self.create_response()
  File "/usr/lib/python2.7/site-packages/streamline/template.py", line 117, in create_response
    super(XHRPartialRoute, self).create_response()
  File "/usr/lib/python2.7/site-packages/streamline/template.py", line 92, in create_response
    super(TemplateRoute, self).create_response()
  File "/usr/lib/python2.7/site-packages/streamline/base.py", line 145, in create_response
    self.body = meth(*self.args, **self.kwargs)
  File "/usr/lib/python2.7/site-packages/librarian/routes/filemanager.py", line 121, in get
    result = self.search(path, show_hidden)
  File "/usr/lib/python2.7/site-packages/librarian/routes/filemanager.py", line 81, in search
    language=language)
  File "/usr/lib/python2.7/site-packages/librarian/data/manager.py", line 224, in search
    is_match=is_match)
  File "/usr/lib/python2.7/site-packages/librarian/data/manager.py", line 109, in _prepare_listing
    current.meta = self._archive.parent(path, refresh)
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 501, in parent
    return self._refresh_parent(path)
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 523, in _refresh_parent
    self.save(raw_data)
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 607, in save
    saved = fs_writer.write()
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 187, in write
    last = self._update(self._path, self._content_types)
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 139, in _update
    entry = self._fetch(path)
  File "/usr/lib/python2.7/site-packages/librarian/data/meta/archive.py", line 101, in _fetch
    return dict(self._db.fetchone(query, (path,)))
TypeError: 'NoneType' object is not iterable
```