### PR TITLE
Account for custom option when validating presets

### DIFF
--- a/librarian/forms/ondd.py
+++ b/librarian/forms/ondd.py
@@ -36,7 +36,7 @@ class LForm(ONDDFormBase):
                 # satellite preset nor 'Custom' option to enter custom data.
                 'required': _("Please select a satellite or select 'Custom'")
             }),
-            form.InRangeValidator(min_value=0, max_value=len(PRESETS))
+            form.InRangeValidator(min_value=-1, max_value=len(PRESETS))
         ]
     )
     frequency = form.FloatField(
@@ -133,7 +133,7 @@ class KuForm(ONDDFormBase):
                 # satellite preset nor 'Custom' option to enter custom data.
                 'required': _("Please select a satellite or select 'Custom'")
             }),
-            form.InRangeValidator(min_value=0, max_value=len(PRESETS))
+            form.InRangeValidator(min_value=-1, max_value=len(PRESETS))
         ]
     )
     # TODO: Add support for DiSEqC azimuth value


### PR DESCRIPTION
The 'Custom' option in tuner presets field has a value of -1, but the form
validates it in the range between 0 and num presets. This means that selecting
custom results in validation failure. This patch fixes the validator to include
-1 for the custom option.