### PR TITLE
Fix/meta handling

### DIFF
--- a/librarian/commands/meta.py
+++ b/librarian/commands/meta.py
@@ -3,23 +3,23 @@ from ..core.exts import ext_container as exts
 from ..data.meta.archive import Archive
 
 
-class RefillFacetsCommand(object):
-    name = 'refill_facets'
-    flags = '--refill-facets'
+class ReloadMetaCommand(object):
+    name = 'reload_meta'
+    flags = '--reload-meta'
     kwargs = {
         'action': 'store_true',
-        'help': "Empty facets archive and reconstruct it."
+        'help': "Empty meta archive and reconstruct it."
     }
 
     def run(self, args):
-        if not args.refill_facets:
-            return
+        exts.events.subscribe('init_complete', self.reload)
 
-        print('Begin facets refill.')
+    def reload(self, *args, **kwargs):
+        print('Begin meta reload.')
         archive = Archive(fsal=exts.fsal,
                           db=exts.databases.librarian,
                           tasks=exts.tasks,
                           config=exts.config)
         archive.clear_and_reload()
-        print('Facet refill finished.')
+        print('Meta reload finished.')
         raise EarlyExit()

--- a/librarian/commands/repl.py
+++ b/librarian/commands/repl.py
@@ -19,8 +19,5 @@ class ReplCommand(object):
         self.repl_thread.join()
 
     def run(self, args):
-        if not args.repl:
-            return
-
         exts.events.subscribe('post_start', self.repl_start)
         exts.events.subscribe('shutdown', self.repl_shutdown)

--- a/librarian/config.ini
+++ b/librarian/config.ini
@@ -245,7 +245,7 @@ collectors =
     core.collectors.templates.Templates
 
 commands =
-    commands.facets.RefillFacetsCommand
+    commands.meta.ReloadMetaCommand
     commands.repl.ReplCommand
 
 dashboard =

--- a/librarian/data/meta/wrapper.py
+++ b/librarian/data/meta/wrapper.py
@@ -22,6 +22,7 @@ class MetaWrapper(object):
 
     def __init__(self, data):
         self._data = data
+        self._metadata = self._data.get('metadata', {})
 
     def get(self, key, language=NO_LANGUAGE, default=None):
         """
@@ -35,11 +36,11 @@ class MetaWrapper(object):
         caster_fn = self.CASTERS.get(key, lambda x: x)
         try:
             # lookup under specific language / key
-            return caster_fn(self._data[language][key])
+            return caster_fn(self._metadata[language][key])
         except KeyError:
             try:
                 # specific language not found, try language-less version
-                return caster_fn(self._data[NO_LANGUAGE][key])
+                return caster_fn(self._metadata[NO_LANGUAGE][key])
             except KeyError:
                 # return default value since no data was found under given keys
                 return default

--- a/librarian/views/filemanager/_html.tpl
+++ b/librarian/views/filemanager/_html.tpl
@@ -2,9 +2,10 @@
     <span class="note">${_('No documents to be shown.')}</span>
 % else:
     <%
-    full_path = th.join(path, selected_name or current.meta.get('main', language=request.locale))
+    full_path = th.join(path, selected_name or
+                              current.meta.get('main', language=request.locale) or
+                              current.meta.get('main', language='__auto__'))
     %>
-
     <div class="views-reader" id="views-reader">
         <iframe class="views-reader-frame" src="${h.quoted_url('filemanager:direct', path=full_path)}" id="views-reader-frame" data-override-partial="${assets['css/overrides']}" data-override-full="${assets['css/restyle']}"></iframe>
     </div>

--- a/librarian/views/filemanager/_html.tpl
+++ b/librarian/views/filemanager/_html.tpl
@@ -2,7 +2,7 @@
     <span class="note">${_('No documents to be shown.')}</span>
 % else:
     <%
-    full_path = th.join(path, selected_name or current.meta.get('main'))
+    full_path = th.join(path, selected_name or current.meta.get('main', language=request.locale))
     %>
 
     <div class="views-reader" id="views-reader">


### PR DESCRIPTION
-Fix meta reload command which is now invoked with the switch `--reload-meta`
-Fix entry point found handler so it checks if the existing entry point
 has a higher score maybe than the new one and keeps the better match
-Adds a new special language key called "__auto__" in order to be able
 to differentiate between entry points found automatically with the
 scoring mechanism and entry points specified explicitly in dirinfo
 files. Those from dirinfo files take precendence over the ones found
 automatically during scoring.