### PR TITLE
Set tempdir location through config

### DIFF
--- a/librarian/config.ini
+++ b/librarian/config.ini
@@ -396,6 +396,11 @@ domains =
 
 save_path = tmp/firmware
 
+[tempfile]
+
+# Global setting for python's tempfile.tempdir attribute
+tempdir = /tmp
+
 [favicon]
 
 path = img/favicon.ico

--- a/librarian/core/contrib/system/config.ini
+++ b/librarian/core/contrib/system/config.ini
@@ -7,3 +7,6 @@ commands =
     commands.ConfigPath
     commands.DebugConfigCommand
     commands.DisplayVersionCommand
+
+hooks =
+    hooks.initialize

--- a/librarian/core/contrib/system/hooks.py
+++ b/librarian/core/contrib/system/hooks.py
@@ -1,0 +1,9 @@
+import tempfile
+
+from ...exports import hook
+from ...exts import ext_container as exts
+
+
+@hook('initialize')
+def initialize(supervisor):
+    tempfile.tempdir = exts.config['tempfile.tempdir']


### PR DESCRIPTION
Add initialize hook to system component which sets the global tempdir location to the path specified in the config file