### PR TITLE
Fix html view auto-opener

### DIFF
--- a/librarian/data/meta/processors.py
+++ b/librarian/data/meta/processors.py
@@ -322,7 +322,18 @@ class HtmlProcessor(Processor):
         # get filenames of passed in paths
         old_name = os.path.basename(old) if old else None
         new_name = os.path.basename(new) if new else None
-        return cls._score(old_name) < cls._score(new_name)
+        # when both candidates are ``None``, don't accept any of them
+        if not old_name and not new_name:
+            return False
+        # if there's no existing entry point, any html will do
+        if not old_name:
+            return True
+        # if there is check if it scores higher by known names
+        if new_name in cls.FILE_NAMES or old_name in cls.FILE_NAMES:
+            return cls._score(old_name) < cls._score(new_name)
+        # if none of the filenames are known entry points, pick the first
+        # one by alphabetical order
+        return new_name < old_name
 
     def process(self):
         super(HtmlProcessor, self).process()

--- a/librarian/routes/filemanager.py
+++ b/librarian/routes/filemanager.py
@@ -101,11 +101,12 @@ class List(FileRouteMixin, XHRPartialRoute):
         except self.manager.InvalidQuery:
             self.abort(404)
 
-    def promote_view(self, view, available_views):
+    def promote_view(self, view, parent):
         # for explicitly chosen views, no auto-promition will be applied
         if self.has_requested_view():
             return view
         # when no view was chosen, auto-promition is allowed
+        available_views = parent.meta.content_type_names
         if ContentTypes.HTML in available_views:
             return ContentTypes.HTML
         # no better match, stick with original plan
@@ -124,8 +125,7 @@ class List(FileRouteMixin, XHRPartialRoute):
         else:
             result = self.list(path, show_hidden, view, selected)
         # perform view promotion, if available
-        available_views = result['current'].meta.content_type_names
-        view = self.promote_view(view, available_views)
+        view = self.promote_view(view, result['current'])
         result.update(is_search=is_search,
                       view=view,
                       selected_name=selected)

--- a/librarian/views/filemanager/_html.tpl
+++ b/librarian/views/filemanager/_html.tpl
@@ -2,9 +2,12 @@
     <span class="note">${_('No documents to be shown.')}</span>
 % else:
     <%
-    full_path = th.join(path, selected_name or
-                              current.meta.get('main', language=request.locale) or
-                              current.meta.get('main', language='__auto__'))
+    filename = (selected_name or current.meta.get('main', language=request.locale) or
+                                 current.meta.get('main', language='__auto__'))
+    if path:
+        full_path = th.join(path, filename)
+    else:
+        full_path = filename
     %>
     <div class="views-reader" id="views-reader">
         <iframe class="views-reader-frame" src="${h.quoted_url('filemanager:direct', path=full_path)}" id="views-reader-frame" data-override-partial="${assets['css/overrides']}" data-override-full="${assets['css/restyle']}"></iframe>

--- a/tests/data/meta/test_processors.py
+++ b/tests/data/meta/test_processors.py
@@ -174,6 +174,9 @@ def test_for_type_success():
     ('index.htm', 'index.html', True),
     ('index.html', 'main.html', False),
     ('index.htm', 'main.html', False),
+    ('start.html', 'custom.html', False),
+    (None, 'custom.html', True),
+    ('custom.html', 'alpha.html', True),
 ])
 def test_is_entry_point(old, new, use):
     assert mod.HtmlProcessor.is_entry_point(new, old) is use


### PR DESCRIPTION
Fix issue when html files are found in a folder but none of their filenames match one of the known html view entry points. For these cases pick the first filename by alphabetical order.