### PR TITLE
Make superuser (possibly) double as system user

### DIFF
--- a/librarian/config.ini
+++ b/librarian/config.ini
@@ -94,6 +94,9 @@ fsal_log = 'tmp/fsal.log'
 # Store setup data in this file
 file = tmp/librarian.json
 
+# Whether superuser creation doubles as system user creation
+super_is_system = no
+
 [database]
 backend = postgres
 # path is still needed when performing cleanup in migrations

--- a/librarian/core/contrib/auth/users.py
+++ b/librarian/core/contrib/auth/users.py
@@ -17,7 +17,8 @@ from .options import Options
 from .utils import generate_random_key
 
 
-USERNAME_REGEX = re.compile(r'^\S{1,12}$')
+# This is the same restriction as the Unix pw, but restricted to 12 characters
+USERNAME_REGEX = re.compile(r'^[a-zA-Z]\w{0,11}$')
 
 
 def authenticated_only(func):

--- a/librarian/forms/auth.py
+++ b/librarian/forms/auth.py
@@ -16,7 +16,25 @@ from bottle import request
 from bottle_utils import form
 from bottle_utils.i18n import lazy_gettext as _
 
-from ..core.contrib.auth.users import User
+from ..core.contrib.auth.users import User, USERNAME_REGEX
+
+
+class Username(form.Validator):
+    USERNAME_RE = USERNAME_REGEX
+
+    messages = {
+        # Translators, error message shown when username does not meet the
+        # requirements during sign-up.
+        'bad_username': _('Usernames must start with an English letter (a-z) '
+                          'and may contain up to 12 letters, numbers and an '
+                          "underscore character, '_'")
+    }
+
+    def validate(self, v):
+        if not v:
+            return
+        if self.USERNAME_RE.match(v.strip()) is None:
+            raise form.ValidationError('bad_username', {'value': v})
 
 
 class TokenValidator(form.Validator):
@@ -83,7 +101,7 @@ class RegistrationForm(form.Form):
     }
     # Translators, used as label in create user form
     username = form.StringField(_("Username"),
-                                validators=[form.Required()],
+                                validators=[form.Required(), Username()],
                                 placeholder=_('username'))
     # Translators, used as label in create user form
     password1 = form.PasswordField(_("Password"),

--- a/librarian/setup/auth.py
+++ b/librarian/setup/auth.py
@@ -55,7 +55,7 @@ class SuperuserStep:
                     db=exts.databases.librarian, reset_token=reset_token)
 
         if not exts.config['setup.super_is_system']:
-            return dict(success=True)
+            return dict(successful=True)
 
         try:
             replace_user(DEFAULT_USER, username, password)

--- a/librarian/utils/sysuser.py
+++ b/librarian/utils/sysuser.py
@@ -15,7 +15,7 @@ import subprocess
 PREFIX = '/usr/sbin'
 DELUSER = PREFIX + '/deluser'
 ADDUSER = PREFIX + '/adduser'
-PASSWD = PREFIX + '/passwd'
+ADDGROUP = PREFIX + '/addgroup'
 
 # Account parameters
 HOME = '/home/outernet'
@@ -33,15 +33,25 @@ def deluser(username):
         raise RuntimeError("could not delete account '{}'".format(username))
 
 
+def addgroup(username, group=None):
+    group = group or username
+    ret = subprocess.call([ADDGROUP, username, username])
+    if ret:
+        raise RuntimeError("could not add '{}' to '{}' group".format(
+            username, group))
+
+
 def adduser(username, password):
     """
     Add a new system user and set its password
     """
     p = subprocess.Popen([ADDUSER, '-u', UID, '-s', SHELL, '-h', HOME,
-                          '-G', SUDO_GROUP, username], stdin=subprocess.PIPE)
+                          username], stdin=subprocess.PIPE)
     p.communicate('{pw}\n{pw}\n'.format(pw=password))
     if not p.returncode == 0:
         raise RuntimeError("Could not create account '{}'".format(username))
+    addgroup(username)
+    addgroup(username, SUDO_GROUP)
 
 
 def replace_user(existing, username, password):

--- a/librarian/utils/sysuser.py
+++ b/librarian/utils/sysuser.py
@@ -1,0 +1,54 @@
+"""
+sysuser.py: System user management under Linux
+
+Copyright 2014-2015, Outernet Inc.
+Some rights reserved.
+
+This software is free software licensed under the terms of GPLv3. See COPYING
+file that comes with the source code, or http://www.gnu.org/licenses/gpl.txt.
+"""
+
+import subprocess
+
+
+# Commands
+PREFIX = '/usr/sbin'
+DELUSER = PREFIX + '/deluser'
+ADDUSER = PREFIX + '/adduser'
+PASSWD = PREFIX + '/passwd'
+
+# Account parameters
+HOME = '/home/outernet'
+UID = '1000'  # must be str for subprocess.Popen
+SHELL = '/bin/sh'
+SUDO_GROUP = 'sudo'
+
+
+def deluser(username):
+    """
+    Delete an existing system user
+    """
+    ret = subprocess.call([DELUSER, username])
+    if ret:
+        raise RuntimeError("could not delete account '{}'".format(username))
+
+
+def adduser(username, password):
+    """
+    Add a new system user and set its password
+    """
+    p = subprocess.Popen([ADDUSER, '-u', UID, '-s', SHELL, '-h', HOME,
+                          '-g', SUDO_GROUP, username], stdin=subprocess.PIPE)
+    p.communicate('{pw}\n{pw}\n'.format(pw=password))
+    if not p.returncode == 0:
+        raise RuntimeError("Could not create account '{}'".format(username))
+
+
+def replace_user(existing, username, password):
+    """
+    Replace existing user with a completely new user account
+
+    Shortcut for doing ``deluser()`` and ``adduser()`` in one go.
+    """
+    deluser(existing)
+    adduser(username, password)

--- a/librarian/utils/sysuser.py
+++ b/librarian/utils/sysuser.py
@@ -38,7 +38,7 @@ def adduser(username, password):
     Add a new system user and set its password
     """
     p = subprocess.Popen([ADDUSER, '-u', UID, '-s', SHELL, '-h', HOME,
-                          '-g', SUDO_GROUP, username], stdin=subprocess.PIPE)
+                          '-G', SUDO_GROUP, username], stdin=subprocess.PIPE)
     p.communicate('{pw}\n{pw}\n'.format(pw=password))
     if not p.returncode == 0:
         raise RuntimeError("Could not create account '{}'".format(username))

--- a/librarian/utils/sysuser.py
+++ b/librarian/utils/sysuser.py
@@ -35,7 +35,7 @@ def deluser(username):
 
 def addgroup(username, group=None):
     group = group or username
-    ret = subprocess.call([ADDGROUP, username, username])
+    ret = subprocess.call([ADDGROUP, username, group])
     if ret:
         raise RuntimeError("could not add '{}' to '{}' group".format(
             username, group))

--- a/librarian/views/setup/step_superuser.tpl
+++ b/librarian/views/setup/step_superuser.tpl
@@ -11,6 +11,7 @@
 <%block name="step_desc">
     <p>
         ${_('The superuser account is used to maintain the library and configure the receiver.')}
+        ${_('The superuser account username and passwrd can also be used in the log-in shell.')}
     </p>
 </%block>
 


### PR DESCRIPTION
This commit introduces some code and a new setting that can cause the superuser
step to create a proper system account as well.

A new boolean configuration option, 'session.super_is_system' is introduced,
which causes the setup wizard step to take additional action when set to true.

The creation of a system user account is currently hard-wired to
/usr/sbin/adduser command (provided by Busybox on Outernet receivers), and is
not expected to work on systems that do not have a Busybox-compatible versions
of these commands. During account creation, an 'outernet' system account is
removed, which is also an assumption that holds true only on Outernet
receivers. Finally, the home directory of the new system account will always be
that of the removed 'outernet' users to simplify account creation.