### PR TITLE
Add link to system root from the Outernet logo

### DIFF
--- a/librarian/views/base.tpl
+++ b/librarian/views/base.tpl
@@ -75,7 +75,13 @@ STATUS_TAB_ID = 'status-tab'
                 %>
                 <${tag_name} href="${nojs.comp_url('menu')}" role="button" aria-controls="${MENUBAR_ID}" class="o-pulldown-menubar-hbar-activator${' o-activator' if show_menu else ''}">
                     <span class="o-pulldown-menubar-hbar-activator-label">
-                        <span class="o-pulldown-menubar-hbar-activator-label-icon icon icon-outernet"></span>
+                        %if not showmenu:
+                        <a href="${url('sys:root')}">
+                        %endif
+                            <span class="o-pulldown-menubar-hbar-activator-label-icon icon icon-outernet"></span>
+                        %if not showmenu:
+                        </a>
+                        %endif
                         <span class="o-pulldown-menubar-hbar-activator-label-text">${_('Toggle apps menu')}</span>
                     </span>
                     % if show_menu:


### PR DESCRIPTION
Since the menu was disabled when there is only 1 item, there had been ne way to
get back to the main page from any of the inner pages. This commit adds a link
to sys:root path from the OUTERNET logo when menu is disabled.

Fixes #363