### PR TITLE
Enable gif format support in image processor

### DIFF
--- a/librarian/data/meta/processors.py
+++ b/librarian/data/meta/processors.py
@@ -351,7 +351,7 @@ class ImageProcessor(Processor, ThumbProcessorMixin):
     name = ContentTypes.IMAGE
     metadata_class = ImageMetadata
 
-    EXTENSIONS = ['jpg', 'jpeg', 'png']
+    EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png']
 
     @staticmethod
     @runnable()


### PR DESCRIPTION
Add gif extension to the list of supported image formats. There was a reason for this list being strict as it looks, which I don't remember, but if needed,we can extend with additional formats for which we are sure they can work.  