### PR TITLE
Add support for compressed html (.htmlgz) files

### DIFF
--- a/librarian/data/meta/processors.py
+++ b/librarian/data/meta/processors.py
@@ -29,6 +29,7 @@ from .utils import runnable
 FILE_TYPE = 0
 DIRECTORY_TYPE = 1
 
+mimetypes.add_type("text/html",".htmlgz",True)
 
 class ThumbProcessorMixin(object):
 

--- a/librarian/helpers/filemanager.py
+++ b/librarian/helpers/filemanager.py
@@ -34,6 +34,7 @@ EXTENSION_VIEW_MAPPING = {
     'html': 'html',
     'htm': 'html',
     'xhtml': 'html',
+    'htmlgz': 'html',
     'mp3': 'audio',
     'wav': 'audio',
     'ogg': 'audio',


### PR DESCRIPTION
This patch enables generating the correct icon and view (Read) for .htmlgz files.
.htmlgz files are .html files compressed with gzip. 
These files are required to support the wikipedia viewer app.

For correct operation, a related rule must also be added to the webserver (lighttpd) config, so that it adds the correct headers for .htmlgz

