### PR TITLE
add .html.gz support

### DIFF
--- a/librarian/data/meta/processors.py
+++ b/librarian/data/meta/processors.py
@@ -30,6 +30,7 @@ FILE_TYPE = 0
 DIRECTORY_TYPE = 1
 
 mimetypes.add_type("text/html",".htmlgz",True)
+mimetypes.add_type("text/html",".html.gz",True)
 
 class ThumbProcessorMixin(object):
 
@@ -296,7 +297,7 @@ class HtmlProcessor(Processor):
     name = ContentTypes.HTML
     metadata_class = HtmlMetadata
 
-    EXTENSIONS = ['html', 'htm', 'xhtml', 'htmlgz']
+    EXTENSIONS = ['html', 'htm', 'xhtml', 'htmlgz', 'html.gz']
     INDEX_NAMES = ['index', 'main', 'start']
     FILE_NAMES = list(reversed(['.'.join(p)
                                 for p in itertools.product(INDEX_NAMES,


### PR DESCRIPTION
.html.gz is much easier for users to work with, when using desktop or outernet_in_a_box.