### PR TITLE
add .html.gz support

### DIFF
--- a/librarian/helpers/filemanager.py
+++ b/librarian/helpers/filemanager.py
@@ -35,6 +35,7 @@ EXTENSION_VIEW_MAPPING = {
     'htm': 'html',
     'xhtml': 'html',
     'htmlgz': 'html',
+    'html.gz': 'html',
     'mp3': 'audio',
     'wav': 'audio',
     'ogg': 'audio',


### PR DESCRIPTION
.html.gz won't work in "Read" tab but is much easier for users using the system without librarian