### PR TITLE
Exclude app logs route from being intercepted by setup plugin so in c…

### DIFF
--- a/librarian/routes/logs.py
+++ b/librarian/routes/logs.py
@@ -12,6 +12,7 @@ from ..data.diagnostics import generate_report
 
 class SendAppLog(NonIterableRouteBase):
     path = '/applog'
+    exclude_plugins = ['setup_plugin']
 
     def get(self):
         log_path = self.config['logging.output']


### PR DESCRIPTION
…ase a step throws an exception, the app log can be downloaded