### PR TITLE
The ftp component of librarian uses multiprocessing, forking the main

### DIFF
--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -9,7 +9,7 @@ cssmin==0.2.0
 # fsal
 gevent==1.0.2
 greenlet==0.4.9
-greentasks==2.0.post1
+greentasks==2.0.post2
 hwd==0.3
 Mako==1.0.3
 MarkupSafe==0.23

--- a/librarian/config.ini
+++ b/librarian/config.ini
@@ -18,7 +18,6 @@ components =
     librarian.core.contrib.cache
     librarian.core.contrib.templates
 
-consume_tasks_delay = 2
 redirect_delay = 5
 
 # IP address range assigned by DHCP to clients
@@ -45,6 +44,14 @@ skip_plugins =
     session
     user
     setup
+
+[tasks]
+
+# Delay between consuming tasks that were scheduled in order
+consume_delay = 2
+
+# Control whether tasks should be executed in forks or not
+multiprocessing = no
 
 [lock]
 # Location of the lock file

--- a/librarian/core/collectors/tasks.py
+++ b/librarian/core/collectors/tasks.py
@@ -12,8 +12,10 @@ class Tasks(ObjectCollectorMixin, ListCollector):
 
     def __init__(self, supervisor):
         super(Tasks, self).__init__(supervisor)
-        delay = supervisor.config['app.consume_tasks_delay']
-        exts.tasks = TaskScheduler(consume_tasks_delay=delay)
+        delay = supervisor.config['tasks.consume_delay']
+        multiprocessing = supervisor.config['tasks.multiprocessing']
+        exts.tasks = TaskScheduler(consume_tasks_delay=delay,
+                                   multiprocessing=multiprocessing)
 
     def install_member(self, task_cls):
         exts.tasks.schedule(task_cls)


### PR DESCRIPTION
process for each client. This caused the whole task scheduler to execute
tasks in parallel from all the processes (main and forks as well), which
lead to unforeseen errors during concurrent database access. The new
version of greentasks has a flag to disallow running from forks, and
this patch sets librarian up to use it.