### PR TITLE
Fix missin folder prefix for captive portal template paths

### DIFF
--- a/librarian/plugins/captive.py
+++ b/librarian/plugins/captive.py
@@ -31,7 +31,7 @@ def captive_portal_plugin(fn):
         elif status == '302':
             return redirect(self_url, 302)
         else:
-            response = template(template_name, {})
+            response = template('captive/{}'.format(template_name), {})
         raise HTTPResponse(response, int(status))
     return wrapper
 captive_portal_plugin.name = 'captive_portal_plugin'


### PR DESCRIPTION
Since the refactoring, captive portal templates have been moved into the captive subfolder, but the plugin was not adjusted to look for them in it,