### PR TITLE
Fix/diskspace multifs

### DIFF
--- a/librarian/config.ini
+++ b/librarian/config.ini
@@ -346,7 +346,6 @@ wizard =
     setup.ondd.ONDDStep
 
 tasks =
-    tasks.diskspace.CheckDiskspaceTask
     tasks.facets.CheckNewContentTask
     tasks.notifications.NotificationCleanupTask
     tasks.ondd.ONDDQueryTask

--- a/librarian/views/diskspace/_consolidate_form.tpl
+++ b/librarian/views/diskspace/_consolidate_form.tpl
@@ -37,8 +37,6 @@
 <%def name="storage_info(storage)">
     <%
         is_loop = storage.name.startswith('loop')
-        usage = storage.stat
-
         if storage.is_loop:
             disk_type = 'internal'
             # Translators, used as description of storage device
@@ -68,13 +66,14 @@
         ${disk_type_label}
     </span>
     <span class="storage-usage storage-detail">
-        ${ui.progress_mini(usage.pct_used)}
+        <% pct_used = storage.used * 100 / storage.total %>
+        ${ui.progress_mini(pct_used)}
         ## Translators, this is used next to disk space usage indicator in settings 
         ## panel. The {used}, {total}, and {free} are placeholders.
         ${_('{used} of {total} ({free} free)').format(
-            used=h.hsize(usage.used),
-            total=h.hsize(usage.total),
-            free=h.hsize(usage.free))}
+            used=h.hsize(storage.used),
+            total=h.hsize(storage.total),
+            free=h.hsize(storage.free))}
     </span>
 </%def>
 


### PR DESCRIPTION
This is a patch on top of the fix/usage-report (see #396) that hard-codes the mount points and allows the diskspace dashboard plugin to behave the same way as before when working on top of multifs setup in rxOS.